### PR TITLE
Add defaultable option for generating types

### DIFF
--- a/src/__snapshots__/util.test.ts.snap
+++ b/src/__snapshots__/util.test.ts.snap
@@ -57,6 +57,19 @@ pub struct RustType {
 "
 `;
 
+exports[`generateRustTypes optional, extra decorators 1`] = `
+"use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = \\"camelCase\\")]
+pub struct RustType {
+    #[serde(skip_serializing_if = \\"Option::is_none\\")]
+    pub value_a: Option<bool>,
+}
+
+"
+`;
+
 exports[`generateRustTypes write to file 1`] = `
 "use serde::{Deserialize, Serialize};
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -25,6 +25,7 @@ export type CodeGenResult = [{ [key: string]: unknown }, string[], string[]]
  * @property {boolean} [nullable=false] Is the validator nullable/optional (default: false)
  * @property {boolean} [comparable=false] Is the validator able to be used in comparisons in other languages (generate comparator function/decorator) (default: false)
  * @property {boolean} [hashable=false] Is the validator able to be hashable in other languages (hashmap usage) (default: false)
+ * @property {boolean} [defaultable=false] Is the validator able to be created with default values in other languages (default: false)
  * @property {string} [typeName='Something'] Required for generating other language types (default: undefined)
  */
 export interface ValidatorOptions {
@@ -34,6 +35,7 @@ export interface ValidatorOptions {
   nullable?: boolean
   comparable?: boolean
   hashable?: boolean
+  defaultable?: boolean
   typeName?: string
 }
 
@@ -74,6 +76,9 @@ export function generateOptionsString(options: ValidatorOptions, defaults: Valid
   if (options.comparable !== undefined && options.comparable !== defaults.comparable) {
     selectedOptions.push(`comparable: ${options.comparable}`)
   }
+  if (options.defaultable !== undefined && options.defaultable !== defaults.defaultable) {
+    selectedOptions.push(`defaultable: ${options.defaultable}`)
+  }
   if (options.hashable !== undefined && options.hashable !== defaults.hashable) {
     selectedOptions.push(`hashable: ${options.hashable}`)
   }
@@ -87,6 +92,7 @@ export abstract class ValidatorBase<T = unknown> {
   public earlyFail: boolean
   public comparable: boolean
   public hashable: boolean
+  public defaultable: boolean
   public typeName: string | undefined
 
   protected codeGenId = 1
@@ -101,6 +107,7 @@ export abstract class ValidatorBase<T = unknown> {
       nullable: false,
       comparable: false,
       hashable: false,
+      defaultable: false,
       typeName: undefined
     }
     const mergedOptions = { ...defaults, ...options }
@@ -112,6 +119,7 @@ export abstract class ValidatorBase<T = unknown> {
     this.nullable = mergedOptions.nullable
     this.comparable = mergedOptions.comparable
     this.hashable = mergedOptions.hashable
+    this.defaultable = mergedOptions.defaultable
     this.typeName = mergedOptions.typeName
     this.optimizedValidate = null
   }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -100,6 +100,22 @@ describe(`serdeDecorators`, () => {
     expect(res).toEqual([`#[derive(Serialize, Deserialize, Debug, Clone, Hash)]`, `#[serde(rename_all = "camelCase")]`])
   })
 
+  it(`defaultable`, () => {
+    const res = serdeDecorators(false, false, true)
+    expect(res).toEqual([
+      `#[derive(Serialize, Deserialize, Debug, Clone, Default)]`,
+      `#[serde(rename_all = "camelCase")]`
+    ])
+  })
+
+  it(`hashable, defaultable`, () => {
+    const res = serdeDecorators(false, true, true)
+    expect(res).toEqual([
+      `#[derive(Serialize, Deserialize, Debug, Clone, Hash, Default)]`,
+      `#[serde(rename_all = "camelCase")]`
+    ])
+  })
+
   it(`comparable and hashable`, () => {
     const res = serdeDecorators(true, true)
     expect(res).toEqual([
@@ -109,7 +125,7 @@ describe(`serdeDecorators`, () => {
   })
 
   it(`with unionKey`, () => {
-    const res = serdeDecorators(false, false, 'type')
+    const res = serdeDecorators(false, false, false, 'type')
     expect(res).toEqual([
       `#[derive(Serialize, Deserialize, Debug, Clone)]`,
       `#[serde(rename_all = "camelCase")]`,
@@ -118,7 +134,7 @@ describe(`serdeDecorators`, () => {
   })
 
   it(`with unionKey and renameAll`, () => {
-    const res = serdeDecorators(false, false, 'type', 'snake_case')
+    const res = serdeDecorators(false, false, false, 'type', 'snake_case')
     expect(res).toEqual([
       `#[derive(Serialize, Deserialize, Debug, Clone)]`,
       `#[serde(rename_all = "snake_case")]`,
@@ -127,7 +143,7 @@ describe(`serdeDecorators`, () => {
   })
 
   it(`comparable, hashable, with unionKey and renameAll`, () => {
-    const res = serdeDecorators(true, true, 'type', 'snake_case')
+    const res = serdeDecorators(true, true, false, 'type', 'snake_case')
     expect(res).toEqual([
       `#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]`,
       `#[serde(rename_all = "snake_case")]`,
@@ -138,7 +154,7 @@ describe(`serdeDecorators`, () => {
 
 describe('serdeDecoratorsString', () => {
   it(`comparable, hashable, with unionKey and renameAll`, () => {
-    const res = serdeDecoratorsString(true, true, 'type', 'snake_case')
+    const res = serdeDecoratorsString(true, true, false, 'type', 'snake_case')
     expect(res).toEqual(
       `#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]\n#[serde(rename_all = "snake_case")]\n#[serde(tag = "type")]\n`
     )
@@ -290,6 +306,19 @@ describe('generateRustTypes', () => {
         valueA: new OptionalBoolean()
       },
       { typeName: 'RustType' }
+    )
+
+    const validators: ValidatorBase[] = [validator]
+    const types = generateRustTypes(validators)
+    expect(types).toMatchSnapshot()
+  })
+
+  it('optional, extra decorators', () => {
+    const validator = new RequiredObject(
+      {
+        valueA: new OptionalBoolean()
+      },
+      { typeName: 'RustType', hashable: true, comparable: true, defaultable: true }
     )
 
     const validators: ValidatorBase[] = [validator]

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,6 +42,7 @@ export function validateRustTypeName(typeName: string, context: ValidatorBase): 
 export function serdeDecorators(
   comparable = false,
   hashable = false,
+  defaultable = false,
   unionKey: string | undefined = undefined,
   renameAll: string | undefined = 'camelCase'
 ): string[] {
@@ -54,6 +55,9 @@ export function serdeDecorators(
   }
   if (hashable === true) {
     deriveMacros.push(`Hash`)
+  }
+  if (defaultable === true) {
+    deriveMacros.push(`Default`)
   }
 
   decorators.push(`#[derive(${deriveMacros.join(', ')})]`)
@@ -72,10 +76,11 @@ export function serdeDecorators(
 export function serdeDecoratorsString(
   comparable = false,
   hashable = false,
+  defaultable = false,
   unionKey: string | undefined = undefined,
   renameAll: string | undefined = 'camelCase'
 ): string {
-  const serdeStr = serdeDecorators(comparable, hashable, unionKey, renameAll)
+  const serdeStr = serdeDecorators(comparable, hashable, defaultable, unionKey, renameAll)
     .map(decorator => decorator + '\n')
     .join('')
   return serdeStr

--- a/src/validators/object.ts
+++ b/src/validators/object.ts
@@ -202,7 +202,7 @@ export abstract class ObjectValidator<T extends ObjectSchema = never, O = never>
             return `${serdeMemberStr}    pub ${toSnakeCase(k)}: ${v.toString({ ...options, parent: this, typeNameFromParent: k })},`
           })
 
-        const serdeStr = serdeDecoratorsString(this.comparable, this.hashable)
+        const serdeStr = serdeDecoratorsString(this.comparable, this.hashable, this.defaultable)
 
         // If part of a Union
         // Don't addTypeDef() when in an enum with wrapped values (non tagged union)

--- a/src/validators/tuple.ts
+++ b/src/validators/tuple.ts
@@ -115,7 +115,7 @@ export abstract class TupleValidator<T extends ValidatorBase[], O = never> exten
           this.comparable = true
         }
 
-        const serdeStr = serdeDecoratorsString(this.comparable, this.hashable)
+        const serdeStr = serdeDecoratorsString(this.comparable, this.hashable, this.defaultable)
 
         // Type generation
         const types = Object.values(this.schema).map(v => v.toString({ ...options, parent: this }))

--- a/src/validators/union.ts
+++ b/src/validators/union.ts
@@ -331,7 +331,7 @@ export abstract class UnionValidator<T extends ValidatorBase[], O = never> exten
           )
         }
 
-        const serdeStr = serdeDecoratorsString(this.comparable, this.hashable, unionKey)
+        const serdeStr = serdeDecoratorsString(this.comparable, this.hashable, this.defaultable, unionKey)
 
         // For a tagged union the 'line' needs to say the value of the tag as a name. Then the struct. So: Name(NameStruct)
         // BUT it CANNOT contain non structs for the value


### PR DESCRIPTION
[sc-118789]
Needed for types where there's a bunch of "Option" values. (And you cannot `impl` types in different crates).

Example:
```
#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
#[serde(skip_serializing_if = "Option::is_none")]
pub enabled_events: Option<Vec>,
```
Used with the `..Default::default()` pattern in tests/initializing and setting single values.