### PR TITLE
array+object: fix missing Option<> on type generation

### DIFF
--- a/src/__snapshots__/util.test.ts.snap
+++ b/src/__snapshots__/util.test.ts.snap
@@ -130,9 +130,9 @@ pub enum Transport {
 #[serde(rename_all = \\"camelCase\\")]
 pub struct RequestDID {
     #[serde(skip_serializing_if = \\"Option::is_none\\")]
-    pub adaption_setup: Vec<String>,
+    pub adaption_setup: Option<Vec<String>>,
     #[serde(skip_serializing_if = \\"Option::is_none\\")]
-    pub adaption_teardown: Vec<String>,
+    pub adaption_teardown: Option<Vec<String>>,
     pub service_and_did: String,
     pub interface: ExternalInterface,
     pub application: Application,

--- a/src/validators/array.ts
+++ b/src/validators/array.ts
@@ -160,7 +160,7 @@ export abstract class ArrayValidator<T extends ValidatorBase = never, O = never>
           schemaStr = `(${schemaStr})`
         }
 
-        const isOption = !this.schema.required || this.schema.nullable
+        const isOption = !this.required || this.nullable
         const typeStr = `Vec<${schemaStr}>`
         return isOption ? `Option<${typeStr}>` : typeStr
       }

--- a/src/validators/object.test.ts
+++ b/src/validators/object.test.ts
@@ -1,3 +1,4 @@
+import { OptionalString, RequiredExactString, RequiredString } from '..'
 import { AssertEqual, ValidatorExportOptions } from '../common'
 import { NotArrayFail, NotFloatFail, NotIntegerFail, NotObjectFail, RequiredFail } from '../errors'
 import { OptionalArray, RequiredArray } from './array'
@@ -745,6 +746,32 @@ pub struct OuterType {
     expect(typeDefinitions).toEqual({
       InnerType: expectedInner,
       OuterType: expectedOuter
+    })
+  })
+
+  it('Required, with an optional array', () => {
+    const validator = new RequiredObject(
+      {
+        a: new OptionalArray(new RequiredString()),
+        b: new OptionalArray(new OptionalString())
+      },
+      { typeName: 'TypeName' }
+    )
+
+    const expectedType = `#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeName {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub a: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub b: Option<Vec<Option<String>>>,
+}
+
+`
+
+    expect(validator.toString(options)).toEqual('TypeName')
+    expect(typeDefinitions).toEqual({
+      TypeName: expectedType
     })
   })
 


### PR DESCRIPTION
[sc-118975]

Had a bug on
```
new RequiredObject({
      description: new RequiredString(),
      transport: new RequiredExactString('IsoTp', { typeName: 'ISO-TP' }),
      txId: new RequiredArray(new RequiredString()),
      txIdExtended: new OptionalArray(new RequiredString()),
      rxId: new RequiredString(),
      responses: new RequiredArray(ecuSimResponseValidator)
    }),
```