### PR TITLE
Fix bug union: Rename tagged union object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedcars/object-validator",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedcars/object-validator",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedcars/object-validator",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Object validator",
   "main": "build/dist/src/index.js",
   "types": "build/dist/src/index.d.ts",

--- a/src/validators/exact-string.test.ts
+++ b/src/validators/exact-string.test.ts
@@ -1,4 +1,4 @@
-import { RequiredObject, RequiredUnion } from '..'
+import { OptionalBoolean, RequiredObject, RequiredUnion } from '..'
 import { AssertEqual, ValidatorExportOptions } from '../common'
 import { NotExactStringFail, RequiredFail } from '../errors'
 import {

--- a/src/validators/union.ts
+++ b/src/validators/union.ts
@@ -347,10 +347,17 @@ export abstract class UnionValidator<T extends ValidatorBase[], O = never> exten
             }
           }
 
+          // Override tag/name
           let overrideNameStr = ``
+          // ExactString
           if (val instanceof ExactStringValidator && val.typeName !== undefined) {
             overrideNameStr += `    #[serde(rename = "${val.typeName}")]\n`
           }
+          // Object
+          if (val instanceof ObjectValidator && unionKey !== undefined && val.schema[unionKey].typeName !== undefined) {
+            overrideNameStr += `    #[serde(rename = "${val.schema[unionKey].typeName}")]\n`
+          }
+
           const typeStr = val.toString({
             ...options,
             parent: this,


### PR DESCRIPTION
Could set custom names on ExactStringValidator, but not on Objects in a union.