### PR TITLE
Union & ExactString: Fix incorrect naming of values (reversed the manual renaming)

### DIFF
--- a/src/__snapshots__/util.test.ts.snap
+++ b/src/__snapshots__/util.test.ts.snap
@@ -99,8 +99,11 @@ pub struct MaineCoonData {
 #[serde(rename_all = \\"camelCase\\")]
 #[serde(tag = \\"type\\")]
 pub enum Cat {
+    #[serde(rename = \\"tabby\\")]
     Tabby(TabbyData),
+    #[serde(rename = \\"tuxedo\\")]
     Tuxedo(TuxedoData),
+    #[serde(rename = \\"maineCoon\\")]
     MaineCoon(MaineCoonData),
 }
 
@@ -111,31 +114,45 @@ pub struct ExternalTuple(u8, u8);
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = \\"camelCase\\")]
 pub enum ExternalInterface {
-    #[serde(rename = \\"RENAMETYPENAME\\")]
-    CAN0,
+    #[serde(rename = \\"CAN0\\")]
+    RENAMETYPENAME,
+    #[serde(rename = \\"CAN1\\")]
     CAN1,
+    #[serde(rename = \\"CAN2\\")]
     CAN2,
+    #[serde(rename = \\"VCAN0\\")]
     VCAN0,
+    #[serde(rename = \\"VCAN1\\")]
     VCAN1,
+    #[serde(rename = \\"VCAN2\\")]
     VCAN2,
+    #[serde(rename = \\"PINS\\")]
     PINS(u8, u8),
+    #[serde(rename = \\"FAKEEXTTUPLE\\")]
     FAKEEXTTUPLE(ExternalTuple),
+    #[serde(rename = \\"FAKEVALUE\\")]
     FAKEVALUE(u8),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = \\"camelCase\\")]
 pub enum Application {
+    #[serde(rename = \\"OBD\\")]
     OBD,
+    #[serde(rename = \\"UDS\\")]
     UDS,
+    #[serde(rename = \\"KWP2000\\")]
     KWP2000,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = \\"camelCase\\")]
 pub enum Transport {
+    #[serde(rename = \\"ISOTP\\")]
     ISOTP,
+    #[serde(rename = \\"TP2\\")]
     TP2,
+    #[serde(rename = \\"ISOTPNOPAD\\")]
     ISOTPNOPAD,
 }
 

--- a/src/validators/exact-string.test.ts
+++ b/src/validators/exact-string.test.ts
@@ -1,4 +1,4 @@
-import { OptionalBoolean, RequiredObject, RequiredUnion } from '..'
+import { RequiredObject, RequiredUnion } from '..'
 import { AssertEqual, ValidatorExportOptions } from '../common'
 import { NotExactStringFail, RequiredFail } from '../errors'
 import {
@@ -194,6 +194,7 @@ describe('Rust Types', () => {
     const expectedNeededUnion = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum NeededUnion {
+    #[serde(rename = "computerKatten")]
     ComputerKatten,
 }
 
@@ -212,8 +213,8 @@ pub enum NeededUnion {
     const expectedNeededUnion = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum NeededUnion {
-    #[serde(rename = "JaMand")]
-    ComputerKatten,
+    #[serde(rename = "computerKatten")]
+    JaMand,
 }
 
 `

--- a/src/validators/exact-string.ts
+++ b/src/validators/exact-string.ts
@@ -98,8 +98,6 @@ export abstract class ExactStringValidator<T extends string = never, O = never> 
           throw new Error(`Rust does not support optional ExactString. For: ${this.toString()}`)
         }
 
-        validateRustTypeName(this.expected, this)
-
         const isValidParent = options?.parent instanceof UnionValidator || options?.parent instanceof ObjectValidator
         if (isValidParent === false) {
           throw new Error(`ExactString has to be in an object/union. str: ${this.expected}`)
@@ -108,7 +106,14 @@ export abstract class ExactStringValidator<T extends string = never, O = never> 
           throw new Error(`ExactString in an object, has to be part of a taggedUnion. str: ${this.expected}`)
         }
 
-        return toPascalCase(this.expected)
+        // Used in unions/enums, the union/enum adds the rename
+        if (this.typeName === undefined) {
+          validateRustTypeName(this.expected, this)
+          return toPascalCase(this.expected)
+        } else {
+          validateRustTypeName(this.typeName, this)
+          return this.typeName
+        }
       }
       default: {
         throw new Error(`Language: '${options?.language}' unknown`)


### PR DESCRIPTION
The old stuff was actually incorrect, only found out a bit later.

Also added rename tag on everything on an enum to avoid mistakes with capitlizations