### PR TITLE
Automatically pass object name/key name to avoid collisions on auto naming

### DIFF
--- a/src/__snapshots__/util.test.ts.snap
+++ b/src/__snapshots__/util.test.ts.snap
@@ -75,21 +75,21 @@ exports[`generateRustTypes write to file 1`] = `
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = \\"camelCase\\")]
-pub struct TabbyData {
+pub struct CatTabbyData {
     pub weight: f32,
     pub age: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = \\"camelCase\\")]
-pub struct TuxedoData {
+pub struct CatTuxedoData {
     pub weight: f32,
     pub age: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = \\"camelCase\\")]
-pub struct MaineCoonData {
+pub struct CatMaineCoonData {
     pub weight: f32,
     pub age: u64,
     pub fur_variant: String,
@@ -100,11 +100,11 @@ pub struct MaineCoonData {
 #[serde(tag = \\"type\\")]
 pub enum Cat {
     #[serde(rename = \\"tabby\\")]
-    Tabby(TabbyData),
+    Tabby(CatTabbyData),
     #[serde(rename = \\"tuxedo\\")]
-    Tuxedo(TuxedoData),
+    Tuxedo(CatTuxedoData),
     #[serde(rename = \\"maineCoon\\")]
-    MaineCoon(MaineCoonData),
+    MaineCoon(CatMaineCoonData),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/validators/array.ts
+++ b/src/validators/array.ts
@@ -1,5 +1,6 @@
 import { CodeGenResult, ValidatorBase, ValidatorExportOptions, ValidatorOptions } from '../common'
 import { NotArrayFail, RequiredFail, ValidationFailure, WrongLengthFail } from '../errors'
+import { toPascalCase } from '../util'
 import { TupleValidator } from './tuple'
 
 export function isArray<T extends ValidatorBase>(
@@ -155,7 +156,29 @@ export abstract class ArrayValidator<T extends ValidatorBase = never, O = never>
         return typeStr
       }
       case 'rust': {
-        let schemaStr = this.schema.toString({ ...options, parent: this })
+        let generatedTypeName: string | undefined = undefined
+        if (options !== undefined) {
+          let firstPart = ``
+          let secondPart = ``
+
+          if (options.parent !== undefined) {
+            if (options.parent.typeName !== undefined) {
+              firstPart += toPascalCase(options.parent.typeName)
+            }
+          }
+
+          if (options.typeNameFromParent !== undefined) {
+            secondPart = toPascalCase(options.typeNameFromParent)
+          }
+
+          generatedTypeName = `${firstPart}${secondPart}`
+        }
+
+        let schemaStr = this.schema.toString({
+          ...options,
+          parent: this,
+          typeNameFromParent: generatedTypeName
+        })
         if (this.schema instanceof TupleValidator && this.schema.typeName === undefined) {
           schemaStr = `(${schemaStr})`
         }

--- a/src/validators/object.test.ts
+++ b/src/validators/object.test.ts
@@ -600,9 +600,9 @@ pub struct OuterType {
       { typeName: 'OuterType' }
     )
 
-    const expectedInner = `#[derive(Serialize, Deserialize, Debug, Clone)]
+    const expectedOther = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct OtherObj {
+pub struct OuterTypeOtherObj {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inner_a: Option<bool>,
 }
@@ -612,14 +612,14 @@ pub struct OtherObj {
 #[serde(rename_all = "camelCase")]
 pub struct OuterType {
     pub outer_a: f32,
-    pub other_obj: OtherObj,
+    pub other_obj: OuterTypeOtherObj,
 }
 
 `
 
     expect(outerValidator.toString(options)).toEqual('OuterType')
     expect(typeDefinitions).toEqual({
-      OtherObj: expectedInner,
+      OuterTypeOtherObj: expectedOther,
       OuterType: expectedOuter
     })
   })

--- a/src/validators/object.ts
+++ b/src/validators/object.ts
@@ -169,10 +169,7 @@ export abstract class ObjectValidator<T extends ObjectSchema = never, O = never>
             } else {
               let firstPart = ``
               if (options.parent.typeName !== undefined) {
-                firstPart += toPascalCase(options.parent.typeName!)
-              } else {
-                console.log(`shitty dooo`)
-                // throw new Error(`Should not shiggy diggy do for: ${options.parent.typeName}`)
+                firstPart += toPascalCase(options.parent.typeName)
               }
               const secondPart = toPascalCase(options.typeNameFromParent)
               const generatedTypeName = `${firstPart}${secondPart}`

--- a/src/validators/object.ts
+++ b/src/validators/object.ts
@@ -167,7 +167,16 @@ export abstract class ObjectValidator<T extends ObjectSchema = never, O = never>
             if (options.typeNameFromParent === undefined) {
               throw new Error(`'typeName' option is not set, and 'options.objectKey' is not set on ${this.toString()}`)
             } else {
-              this.typeName = toPascalCase(`${options.typeNameFromParent}`)
+              let firstPart = ``
+              if (options.parent.typeName !== undefined) {
+                firstPart += toPascalCase(options.parent.typeName!)
+              } else {
+                console.log(`shitty dooo`)
+                // throw new Error(`Should not shiggy diggy do for: ${options.parent.typeName}`)
+              }
+              const secondPart = toPascalCase(options.typeNameFromParent)
+              const generatedTypeName = `${firstPart}${secondPart}`
+              this.typeName = generatedTypeName
             }
           }
         }

--- a/src/validators/sample.test.ts
+++ b/src/validators/sample.test.ts
@@ -417,7 +417,7 @@ describe('Rust Types', () => {
         tagDepth: 3.1416
       }
     },
-    positions: [
+    positionNoExtra: [
       {
         latitude: 55.332131,
         longitude: 12.54454,
@@ -444,7 +444,7 @@ describe('Rust Types', () => {
 
     const expectedExtra = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Extra {
+pub struct TypeNamePositionExtra {
     pub tag: String,
     pub tagversion: i64,
     pub tag_depth: f32,
@@ -454,18 +454,18 @@ pub struct Extra {
 
     const expectedPosition = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Position {
+pub struct TypeNamePosition {
     pub latitude: f32,
     pub longitude: f32,
     pub accuracy: i64,
-    pub extra: Extra,
+    pub extra: TypeNamePositionExtra,
 }
 
 `
 
-    const expectedPositions = `#[derive(Serialize, Deserialize, Debug, Clone)]
+    const expectedPositionNoExtra = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Positions {
+pub struct TypeNamePositionNoExtra {
     pub latitude: f32,
     pub longitude: f32,
     pub accuracy: i64,
@@ -481,16 +481,16 @@ pub struct TypeName {
     pub recorded_at: DateTime<Utc>,
     pub trip_id: i64,
     pub value: i64,
-    pub position: Position,
-    pub positions: Vec<Positions>,
+    pub position: TypeNamePosition,
+    pub position_no_extra: Vec<TypeNamePositionNoExtra>,
 }
 
 `
 
     expect(typeDefinitions).toEqual({
-      Extra: expectedExtra,
-      Position: expectedPosition,
-      Positions: expectedPositions,
+      TypeNamePosition: expectedPosition,
+      TypeNamePositionExtra: expectedExtra,
+      TypeNamePositionNoExtra: expectedPositionNoExtra,
       TypeName: expectedTypeName
     })
   })
@@ -501,7 +501,7 @@ pub struct TypeName {
 
     const expectedExtra = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Extra {
+pub struct TypeNamePositionExtra {
     pub tag: String,
     pub tagversion: i64,
     pub tag_depth: f32,
@@ -511,18 +511,18 @@ pub struct Extra {
 
     const expectedPosition = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Position {
+pub struct TypeNamePosition {
     pub latitude: f32,
     pub longitude: f32,
     pub accuracy: i64,
-    pub extra: Extra,
+    pub extra: TypeNamePositionExtra,
 }
 
 `
 
-    const expectedPositions = `#[derive(Serialize, Deserialize, Debug, Clone)]
+    const expectedPositionNoExtra = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Positions {
+pub struct TypeNamePositionNoExtra {
     pub latitude: f32,
     pub longitude: f32,
     pub accuracy: i64,
@@ -538,16 +538,16 @@ pub struct TypeName {
     pub recorded_at: DateTime<Utc>,
     pub trip_id: i64,
     pub value: i64,
-    pub position: Position,
-    pub positions: Vec<Positions>,
+    pub position: TypeNamePosition,
+    pub position_no_extra: Vec<TypeNamePositionNoExtra>,
 }
 
 `
 
     expect(typeDefinitions).toEqual({
-      Extra: expectedExtra,
-      Position: expectedPosition,
-      Positions: expectedPositions,
+      TypeNamePosition: expectedPosition,
+      TypeNamePositionExtra: expectedExtra,
+      TypeNamePositionNoExtra: expectedPositionNoExtra,
       TypeName: expectedTypeName
     })
   })

--- a/src/validators/union.test.ts
+++ b/src/validators/union.test.ts
@@ -1186,14 +1186,14 @@ pub enum RustEnum {
 
     const expectedKat = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct KatData {
+pub struct RustEnumKatData {
     pub ja: bool,
 }
 
 `
     const expectedMis = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct MisData {
+pub struct RustEnumMisData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ja: Option<bool>,
 }
@@ -1204,16 +1204,16 @@ pub struct MisData {
 #[serde(tag = "bingoTag")]
 pub enum RustEnum {
     #[serde(rename = "kat")]
-    Kat(KatData),
+    Kat(RustEnumKatData),
     #[serde(rename = "mis")]
-    Mis(MisData),
+    Mis(RustEnumMisData),
 }
 
 `
     expect(validator.toString(options)).toEqual(`RustEnum`)
     expect(typeDefinitions).toEqual({
-      KatData: expectedKat,
-      MisData: expectedMis,
+      RustEnumKatData: expectedKat,
+      RustEnumMisData: expectedMis,
       RustEnum: expectedEnum
     })
   })
@@ -1260,7 +1260,7 @@ pub enum RustEnum {
 
     const expectedMis = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct MisData {
+pub struct RustEnumMisData {
     pub a: bool,
 }
 
@@ -1272,13 +1272,13 @@ pub enum RustEnum {
     #[serde(rename = "kat")]
     Kat,
     #[serde(rename = "mis")]
-    Mis(MisData),
+    Mis(RustEnumMisData),
 }
 
 `
     expect(validator.toString(options)).toEqual(`RustEnum`)
     expect(typeDefinitions).toEqual({
-      MisData: expectedMis,
+      RustEnumMisData: expectedMis,
       RustEnum: expectedEnum
     })
   })
@@ -1374,14 +1374,14 @@ pub enum RustEnum {
 
     const expectedOutside1 = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct KatData {
+pub struct RustEnumKatData {
     pub ja: bool,
 }
 
 `
     const expectedOutside2 = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct MisData {
+pub struct RustEnumMisData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ja: Option<bool>,
 }
@@ -1400,9 +1400,9 @@ pub struct SpecificTypeName {
 #[serde(tag = "bingoTag")]
 pub enum RustEnum {
     #[serde(rename = "Kat")]
-    Kat(KatData),
+    Kat(RustEnumKatData),
     #[serde(rename = "Mis")]
-    Mis(MisData),
+    Mis(RustEnumMisData),
     #[serde(rename = "Specific")]
     Specific(SpecificTypeName),
 }
@@ -1410,8 +1410,8 @@ pub enum RustEnum {
 `
     expect(validator.toString(options)).toEqual(`RustEnum`)
     expect(typeDefinitions).toEqual({
-      KatData: expectedOutside1,
-      MisData: expectedOutside2,
+      RustEnumKatData: expectedOutside1,
+      RustEnumMisData: expectedOutside2,
       SpecificTypeName: expectedOutside3,
       RustEnum: expectedEnum
     })
@@ -1457,7 +1457,7 @@ pub enum UnionName {
 
     const expectedJaMand = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct JaMandData {
+pub struct UnionNameJaMandData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hello: Option<bool>,
 }
@@ -1468,12 +1468,12 @@ pub struct JaMandData {
 #[serde(tag = "bingo")]
 pub enum UnionName {
     #[serde(rename = "computerKatten")]
-    JaMand(JaMandData),
+    JaMand(UnionNameJaMandData),
 }
 
 `
     expect(typeDefinitions).toEqual({
-      JaMandData: expectedJaMand,
+      UnionNameJaMandData: expectedJaMand,
       UnionName: expectedNeededUnion
     })
   })
@@ -1508,7 +1508,7 @@ pub struct DoubleRenameFun {
 
     const expectedAutoNaming = `#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ComputerHundenData {
+pub struct UnionNameComputerHundenData {
     pub hej: bool,
 }
 
@@ -1521,13 +1521,13 @@ pub enum UnionName {
     #[serde(rename = "computerKatten")]
     JaMand(DoubleRenameFun),
     #[serde(rename = "computerHunden")]
-    ComputerHunden(ComputerHundenData),
+    ComputerHunden(UnionNameComputerHundenData),
 }
 
 `
     expect(typeDefinitions).toEqual({
       DoubleRenameFun: expectedDoubleRenameFun,
-      ComputerHundenData: expectedAutoNaming,
+      UnionNameComputerHundenData: expectedAutoNaming,
       UnionName: expectedNeededUnion
     })
 


### PR DESCRIPTION
prop names are usually very simple, and will easily get collisions.
pass in the name of the enum/object first to avoid having to name everything manually

[sc-122159]